### PR TITLE
Allow silent uninstaller

### DIFF
--- a/nsis/devkitPro.nsi
+++ b/nsis/devkitPro.nsi
@@ -1,7 +1,6 @@
 RequestExecutionLevel admin ;Require admin rights on NT6+ (When UAC is turned on)
 
 ; plugins required
-; untgz          - http://nsis.sourceforge.net/UnTGZ_plug-in
 ; inetc          - http://nsis.sourceforge.net/Inetc_plug-in
 ;                  http://forums.winamp.com/showthread.php?s=&threadid=198596&perpage=40&highlight=&pagenumber=4
 ;                  http://forums.winamp.com/attachment.php?s=&postid=1831346

--- a/nsis/devkitPro.nsi
+++ b/nsis/devkitPro.nsi
@@ -660,16 +660,16 @@ FunctionEnd
 Function un.onUninstSuccess
 ;-----------------------------------------------------------------------------------------------------------------------
   HideWindow
-  MessageBox MB_ICONINFORMATION|MB_OK "All devkitPro packages were successfully removed from your computer."
+  MessageBox MB_ICONINFORMATION|MB_OK "All devkitPro packages were successfully removed from your computer." /SD IDOK
 FunctionEnd
 
 ;-----------------------------------------------------------------------------------------------------------------------
 Function un.onInit
 ;-----------------------------------------------------------------------------------------------------------------------
-  MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you sure you want to completely remove all devkitPro packages?" IDYES +2
+  MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you sure you want to completely remove all devkitPro packages?" /SD IDYES IDYES +2
   Abort
 
-  MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you absolutely sure you want to do this?$\r$\nThis will remove the whole devkitPro folder and it's contents." IDYES +2
+  MessageBox MB_ICONQUESTION|MB_YESNO|MB_DEFBUTTON2 "Are you absolutely sure you want to do this?$\r$\nThis will remove the whole devkitPro folder and it's contents." /SD IDYES IDYES +2
   Abort
 
 FunctionEnd


### PR DESCRIPTION
This PR will allow using a silent uninstaller (no dialog boxes).

In a **MessageBox**, the **/SD** parameter with a value will be used to specify the option that will be used when the uninstaller is silent. The default options in the message boxes is to uninstall devkitPro.

How to run the silent mode with NSIS:
```text
powershell -command start-process C:\devkitPro\uninst.exe -ArgumentList '/S' -Wait
```

More info at https://nsis.sourceforge.io/Docs/Chapter4.html#silent

My next step is to be able to use the silent installer, but I'm having some problems. So this will be in another PR if I'm able to fix my issues.